### PR TITLE
Skip applet selection dialog when user has no existing applets

### DIFF
--- a/src/pages/Cart.vue
+++ b/src/pages/Cart.vue
@@ -107,6 +107,7 @@ export default {
       'fromBuilder',
       'allAccounts',
       'ownerAccount',
+      'currentApplets',
     ]),
     ...mapGetters([
       'isLoggedIn'
@@ -167,8 +168,12 @@ export default {
     },
 
     onSelectApplet() {
-      this.step = 'SELECT_APPLET';
-      this.showSelectAppletDialog = true;
+      if (this.currentApplets.length > 0) {
+        this.step = 'SELECT_APPLET';
+        this.showSelectAppletDialog = true;
+      } else {
+        this.onSelectedApplet(null);
+      }
     },
     onSelectedApplet(selectedApplet) {
       this.selectedApplet = selectedApplet;


### PR DESCRIPTION
# Resolves [#54](https://app.zenhub.com/workspaces/mindlogger-webapp-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-website/54)